### PR TITLE
Fix Visual Studio build

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -1,14 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
-set -x
+set -ex
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     brew update || brew update
     brew outdated pyenv || brew upgrade pyenv
     brew install pyenv-virtualenv
     brew install cmake || true
-    brew install nasm || true
 
     if which pyenv > /dev/null; then
         eval "$(pyenv init -)"
@@ -18,9 +16,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     pyenv virtualenv 3.7.1 conan
     pyenv rehash
     pyenv activate conan
-else
-    sudo apt-get update
-    sudo apt-get install -y --no-install-recommends nasm autoconf dh-autoreconf
 fi
 
 pip install conan --upgrade

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
-set -x
+set -ex
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     if which pyenv > /dev/null; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,22 +7,28 @@ environment:
         - MINGW_CONFIGURATIONS: '4.9@x86_64@seh@posix, 4.9@x86_64@sjlj@posix, 4.9@x86@sjlj@posix, 4.9@x86@dwarf2@posix, 6@x86@dwarf2@posix, 6@x86_64@seh@posix, 7@x86@dwarf2@posix, 7@x86_64@seh@posix, 8@x86@dwarf2@posix, 8@x86_64@seh@posix'
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 12
-          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86
+          CPU: x86
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 12
-          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
+          CPU: AMD64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
-          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86
+          CPU: x86
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
-          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
+          CPU: AMD64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
-          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86
+          CPU: x86
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
-          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
+          CPU: AMD64
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,6 @@
 
 import os
 import shutil
-import platform
 from conans import ConanFile, AutoToolsBuildEnvironment, tools
 
 


### PR DESCRIPTION
When using cross building (x86_64 to x86) on Windows + Visual Studio, the env CPU is only detected as AMD64

fixes https://github.com/bincrafters/community/issues/754